### PR TITLE
Backport upstream fix for test failure

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -1,7 +1,7 @@
 aws_c_common:
 - 0.8.3
 aws_c_io:
-- 0.13.4
+- 0.13.5
 c_compiler:
 - gcc
 c_compiler_version:

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -3,7 +3,7 @@ BUILD:
 aws_c_common:
 - 0.8.3
 aws_c_io:
-- 0.13.4
+- 0.13.5
 c_compiler:
 - gcc
 c_compiler_version:

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -1,7 +1,7 @@
 aws_c_common:
 - 0.8.3
 aws_c_io:
-- 0.13.4
+- 0.13.5
 c_compiler:
 - gcc
 c_compiler_version:

--- a/.ci_support/migrations/aws_c_io0135.yaml
+++ b/.ci_support/migrations/aws_c_io0135.yaml
@@ -1,0 +1,8 @@
+__migrator:
+  build_number: 1
+  kind: version
+  migration_number: 1
+  automerge: true
+aws_c_io:
+- 0.13.5
+migrator_ts: 1665720916.6864688

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 aws_c_common:
 - 0.8.3
 aws_c_io:
-- 0.13.4
+- 0.13.5
 c_compiler:
 - clang
 c_compiler_version:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 aws_c_common:
 - 0.8.3
 aws_c_io:
-- 0.13.4
+- 0.13.5
 c_compiler:
 - clang
 c_compiler_version:

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -1,7 +1,7 @@
 aws_c_common:
 - 0.8.3
 aws_c_io:
-- 0.13.4
+- 0.13.5
 c_compiler:
 - vs2019
 channel_sources:

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @xhochy
+* @conda-forge/aws-sdk-cpp @xhochy

--- a/README.md
+++ b/README.md
@@ -197,5 +197,6 @@ In order to produce a uniquely identifiable distribution:
 Feedstock Maintainers
 =====================
 
+* [@conda-forge/aws-sdk-cpp](https://github.com/conda-forge/aws-sdk-cpp/)
 * [@xhochy](https://github.com/xhochy/)
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,3 +43,4 @@ about:
 extra:
   recipe-maintainers:
     - xhochy
+    - conda-forge/aws-sdk-cpp

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,12 +1,11 @@
-{% set name = "aws-c-http" %}
 {% set version = "0.6.23" %}
 
 package:
-  name: {{ name|lower }}
+  name: aws-c-http
   version: {{ version }}
 
 source:
-  url: https://github.com/awslabs/{{ name }}/archive/v{{ version }}.tar.gz
+  url: https://github.com/awslabs/aws-c-http/archive/v{{ version }}.tar.gz
   sha256: cac4493a910b04c883afd1f3e1d842fb5810ea6ea358c970c12190b78a245bbe
   patches:
     # backport https://github.com/awslabs/aws-c-http/issues/393

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,9 +8,12 @@ package:
 source:
   url: https://github.com/awslabs/{{ name }}/archive/v{{ version }}.tar.gz
   sha256: cac4493a910b04c883afd1f3e1d842fb5810ea6ea358c970c12190b78a245bbe
+  patches:
+    # backport https://github.com/awslabs/aws-c-http/issues/393
+    - patches/Empty-path.patch
 
 build:
-  number: 1
+  number: 2
   run_exports:
     - {{ pin_subpackage("aws-c-http", max_pin="x.x.x") }}
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: cac4493a910b04c883afd1f3e1d842fb5810ea6ea358c970c12190b78a245bbe
 
 build:
-  number: 0
+  number: 1
   run_exports:
     - {{ pin_subpackage("aws-c-http", max_pin="x.x.x") }}
 

--- a/recipe/patches/Empty-path.patch
+++ b/recipe/patches/Empty-path.patch
@@ -1,0 +1,148 @@
+From e80c70d75f58a5b62870ac980cc3abff1f38db1f Mon Sep 17 00:00:00 2001
+From: Dmitriy Musatkin <63878209+DmitriyMusatkin@users.noreply.github.com>
+Date: Mon, 31 Oct 2022 13:33:59 -0700
+Subject: [PATCH] Empty path (#395)
+
+* fix handling of empty path in tests
+---
+ .github/workflows/ci.yml     | 31 ++++++++++++++++---------------
+ .gitignore                   |  1 +
+ bin/elasticurl/main.c        |  7 ++++++-
+ source/request_response.c    |  2 +-
+ tests/test_localhost_integ.c |  2 +-
+ tests/test_stream_manager.c  | 10 ++++++++--
+ 6 files changed, 33 insertions(+), 20 deletions(-)
+
+diff --git a/.github/workflows/ci.yml b/.github/workflows/ci.yml
+index a9cbe656..184ba37d 100644
+--- a/.github/workflows/ci.yml
++++ b/.github/workflows/ci.yml
+@@ -155,21 +155,22 @@ jobs:
+         python3 -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder.pyz')"
+         python3 builder.pyz build -p aws-c-http --cmake-extra=-DENABLE_LOCALHOST_INTEGRATION_TESTS=ON
+ 
+-  localhost-test-mac:
+-    runs-on: macos-11 # latest
+-    steps:
+-    - name: Checkout
+-      uses: actions/checkout@v3
+-    - name: Configure local host
+-      run: |
+-        python3 -m pip install h2
+-        cd ./tests/py_localhost/
+-        python3 server.py &
+-        python3 non_tls_server.py &
+-    - name: Build and test
+-      run: |
+-        python3 -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder.pyz')"
+-        python3 builder.pyz build -p aws-c-http --cmake-extra=-DENABLE_LOCALHOST_INTEGRATION_TESTS=ON
++  # localhost tests are flaky on mac. disable for now, put fixing it in backlog
++  # localhost-test-mac:
++  #   runs-on: macos-11 # latest
++  #   steps:
++  #   - name: Checkout
++  #     uses: actions/checkout@v3
++  #   - name: Configure local host
++  #     run: |
++  #       python3 -m pip install h2
++  #       cd ./tests/py_localhost/
++  #       python3 server.py &
++  #       python3 non_tls_server.py &
++  #   - name: Build and test
++  #     run: |
++  #       python3 -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder.pyz')"
++  #       python3 builder.pyz build -p aws-c-http --cmake-extra=-DENABLE_LOCALHOST_INTEGRATION_TESTS=ON
+ 
+   localhost-test-win:
+     runs-on: windows-2022 # latest
+diff --git a/.gitignore b/.gitignore
+index 2d07c154..17d37a49 100644
+--- a/.gitignore
++++ b/.gitignore
+@@ -9,6 +9,7 @@ Release
+ *#
+ *.iml
+ tags
++.vscode
+ 
+ #vim swap file
+ *.swp
+diff --git a/bin/elasticurl/main.c b/bin/elasticurl/main.c
+index 3e78541d..38ded84c 100644
+--- a/bin/elasticurl/main.c
++++ b/bin/elasticurl/main.c
+@@ -404,7 +404,12 @@ static struct aws_http_message *s_build_http_request(
+     }
+ 
+     aws_http_message_set_request_method(request, aws_byte_cursor_from_c_str(app_ctx->verb));
+-    aws_http_message_set_request_path(request, app_ctx->uri.path_and_query);
++    if (app_ctx->uri.path_and_query.len != 0) {
++        aws_http_message_set_request_path(request, app_ctx->uri.path_and_query);
++    } else {
++        aws_http_message_set_request_path(request, aws_byte_cursor_from_c_str("/"));
++    }
++
+     if (protocol_version == AWS_HTTP_VERSION_2) {
+         struct aws_http_headers *h2_headers = aws_http_message_get_headers(request);
+         aws_http2_headers_set_request_scheme(h2_headers, app_ctx->uri.scheme);
+diff --git a/source/request_response.c b/source/request_response.c
+index 51baec1b..49258fe4 100644
+--- a/source/request_response.c
++++ b/source/request_response.c
+@@ -28,7 +28,7 @@ bool aws_http_header_name_eq(struct aws_byte_cursor name_a, struct aws_byte_curs
+ }
+ 
+ /**
+- * -- Datastructure Notes --
++ * -- Data Structure Notes --
+  * Headers are stored in a linear array, rather than a hash-table of arrays.
+  * The linear array was simpler to implement and may be faster due to having fewer allocations.
+  * The API has been designed so we can swap out the implementation later if desired.
+diff --git a/tests/test_localhost_integ.c b/tests/test_localhost_integ.c
+index 9797db4d..d7b35b21 100644
+--- a/tests/test_localhost_integ.c
++++ b/tests/test_localhost_integ.c
+@@ -241,7 +241,7 @@ static int s_tester_init(struct tester *tester, struct aws_allocator *allocator,
+         .keep_alive_interval_sec = 0,
+     };
+     struct aws_http_connection_monitoring_options monitor_opt = {
+-        .allowable_throughput_failure_interval_seconds = 1,
++        .allowable_throughput_failure_interval_seconds = 2,
+         .minimum_throughput_bytes_per_second = 1000,
+     };
+     struct aws_http_client_connection_options client_options = {
+diff --git a/tests/test_stream_manager.c b/tests/test_stream_manager.c
+index 9b698f5d..119bedf5 100644
+--- a/tests/test_stream_manager.c
++++ b/tests/test_stream_manager.c
+@@ -530,6 +530,12 @@ static int s_sm_stream_acquiring_customize_request(
+     return AWS_OP_SUCCESS;
+ }
+ 
++static struct aws_byte_cursor s_default_empty_path = AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("/");
++
++struct aws_byte_cursor s_normalize_path(struct aws_byte_cursor path) {
++    return path.len == 0 ? s_default_empty_path : path;
++}
++
+ static int s_sm_stream_acquiring(int num_streams) {
+     struct aws_http_message *request = aws_http2_message_new_request(s_tester.allocator);
+     ASSERT_NOT_NULL(request);
+@@ -542,7 +548,7 @@ static int s_sm_stream_acquiring(int num_streams) {
+         },
+         {
+             .name = aws_byte_cursor_from_c_str(":path"),
+-            .value = *aws_uri_path(&s_tester.endpoint),
++            .value = s_normalize_path(*aws_uri_path(&s_tester.endpoint)),
+         },
+         {
+             .name = aws_byte_cursor_from_c_str(":authority"),
+@@ -1351,7 +1357,7 @@ static int s_sm_stream_acquiring_with_body(int num_streams) {
+         },
+         {
+             .name = aws_byte_cursor_from_c_str(":path"),
+-            .value = *aws_uri_path(&s_tester.endpoint),
++            .value = s_normalize_path(*aws_uri_path(&s_tester.endpoint)),
+         },
+         {
+             .name = aws_byte_cursor_from_c_str(":authority"),


### PR DESCRIPTION
I'm basing this on #83 because the aws-c-* migrators are starting to pile up on each other in incompatible ways, and going one by one version increments hopefully allows to break some of those gridlocks (i.e. some packages were already migrated to 0.3.15, then themselves migrated, etc.).

Also proposing to add @conda-forge/aws-sdk-cpp as a maintainer to all of the aws-c-* feedstocks, so that people can join the whole stack, rather than have to do it for every single feedstock.

Closes #83 